### PR TITLE
boring avatars was installed on the wrong directory

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.6",
     "@reduxjs/toolkit": "^1.9.5",
+    "boring-avatars": "^1.10.1",
     "moment": "^2.29.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Adds boring avatars to correct directory, seems it was installed in the main directory, not client.